### PR TITLE
Fix/firebase db integration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,8 @@ jobs:
           VITE_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
           VITE_FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
 
       - uses: actions/configure-pages@v4
 

--- a/assets/js/lib/firebase.ts
+++ b/assets/js/lib/firebase.ts
@@ -20,15 +20,19 @@ export type ScoreRecord = {
   createdAt: Timestamp;
 };
 
-const app = initializeApp({
+const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
   authDomain: `${import.meta.env.VITE_FIREBASE_PROJECT_ID}.firebaseapp.com`,
   projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
   storageBucket: `${import.meta.env.VITE_FIREBASE_PROJECT_ID}.firebasestorage.app`,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
   appId: import.meta.env.VITE_FIREBASE_APP_ID,
-});
+  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
+};
 
+const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
+
 const scoresCol = collection(db, 'scores');
 
 export async function submitScore(name: string, score: number): Promise<string> {

--- a/assets/js/main.ts
+++ b/assets/js/main.ts
@@ -268,7 +268,7 @@ function main(): void {
 
       if (!mainElement.querySelector('.ranking-list')) return; // navigated away
 
-      if (submissionError) {
+      if (submissionError && !mainElement.querySelector('.ranking-save-error')) {
         const overlay = mainElement.querySelector('.ranking-overlay');
         const title = overlay?.querySelector('.ranking-title');
         if (overlay && title) {
@@ -329,6 +329,18 @@ function main(): void {
       listEl.innerHTML = html;
     } catch {
       if (!mainElement.querySelector('.ranking-list')) return;
+      const { error: submissionError } = await submission;
+      if (!mainElement.querySelector('.ranking-list')) return;
+      if (submissionError && !mainElement.querySelector('.ranking-save-error')) {
+        const overlay = mainElement.querySelector('.ranking-overlay');
+        const title = overlay?.querySelector('.ranking-title');
+        if (overlay && title) {
+          const banner = document.createElement('p');
+          banner.className = 'ranking-save-error';
+          banner.textContent = '> score could not be saved.';
+          overlay.insertBefore(banner, title);
+        }
+      }
       listEl.innerHTML = `
         <p class="ranking-error">&gt; could not load rankings.</p>
         <a class="ranking-retry" href="#">try again</a>

--- a/assets/js/main.ts
+++ b/assets/js/main.ts
@@ -223,26 +223,20 @@ function main(): void {
     const scoreEl = gameOverScreen.querySelector('.go-score-value');
     if (scoreEl) scoreEl.textContent = String(score);
 
-    // Submit score non-blocking; snapshot state at transition time (default: failed)
-    let submissionState: { error: boolean; docId: string | null } = { error: true, docId: null };
+    const submission: Promise<{ error: boolean; docId: string | null }> = submitScore(playerName, score)
+      .then((docId) => ({ error: false, docId }))
+      .catch(() => ({ error: true, docId: null }));
 
-    submitScore(playerName, score)
-      .then((docId) => { submissionState = { error: false, docId }; })
-      .catch(() => { submissionState = { error: true, docId: null }; });
-
-    setTimeout(() => {
-      createRankingScreen(score, submissionState.error, submissionState.docId);
-    }, GAME_OVER_TRANSITION_MS);
+    setTimeout(() => createRankingScreen(score, submission), GAME_OVER_TRANSITION_MS);
   }
 
-  function createRankingScreen(currentScore: number, submissionError = false, submittedDocId: string | null = null): void {
+  function createRankingScreen(currentScore: number, submission: Promise<{ error: boolean; docId: string | null }>): void {
     const size = getCanvasSize();
     buildDom(`
       <section class="section-container ranking-screen">
         <div class="crt-frame">
           <canvas class="ranking-canvas"></canvas>
           <div class="ranking-overlay">
-            ${submissionError ? '<p class="ranking-save-error">&gt; score could not be saved.</p>' : ''}
             <h1 class="ranking-title">Hall of Fame</h1>
             <div class="ranking-list">
               <p class="ranking-loading">&gt; loading...</p>
@@ -259,17 +253,31 @@ function main(): void {
 
     mainElement.querySelector('.ranking-play-again')!.addEventListener('click', createStartScreen);
 
-    loadRanking(currentScore, submittedDocId);
+    loadRanking(currentScore, submission);
   }
 
-  async function loadRanking(currentScore: number, submittedDocId: string | null): Promise<void> {
+  async function loadRanking(currentScore: number, submission: Promise<{ error: boolean; docId: string | null }>): Promise<void> {
     const listEl = mainElement.querySelector('.ranking-list');
     if (!listEl) return;
 
     try {
-      const scores = await fetchTopScores(10);
+      const [scores, { error: submissionError, docId: submittedDocId }] = await Promise.all([
+        fetchTopScores(10),
+        submission,
+      ]);
 
       if (!mainElement.querySelector('.ranking-list')) return; // navigated away
+
+      if (submissionError) {
+        const overlay = mainElement.querySelector('.ranking-overlay');
+        const title = overlay?.querySelector('.ranking-title');
+        if (overlay && title) {
+          const banner = document.createElement('p');
+          banner.className = 'ranking-save-error';
+          banner.textContent = '> score could not be saved.';
+          overlay.insertBefore(banner, title);
+        }
+      }
 
       if (scores.length === 0) {
         let html = '<p class="ranking-empty">&gt; no scores yet — be the first!</p>';
@@ -328,7 +336,7 @@ function main(): void {
       listEl.querySelector('.ranking-retry')?.addEventListener('click', (e) => {
         e.preventDefault();
         listEl.innerHTML = '<p class="ranking-loading">&gt; loading...</p>';
-        loadRanking(currentScore, submittedDocId);
+        loadRanking(currentScore, submission);
       });
     }
   }

--- a/assets/js/main.ts
+++ b/assets/js/main.ts
@@ -223,15 +223,15 @@ function main(): void {
     const scoreEl = gameOverScreen.querySelector('.go-score-value');
     if (scoreEl) scoreEl.textContent = String(score);
 
-    // Submit score non-blocking; capture doc id and error flag for ranking screen
-    const submissionResult = submitScore(playerName, score)
-      .then((docId) => ({ error: false, docId }))
-      .catch(() => ({ error: true, docId: null }));
+    // Submit score non-blocking; snapshot state at transition time (default: failed)
+    let submissionState: { error: boolean; docId: string | null } = { error: true, docId: null };
+
+    submitScore(playerName, score)
+      .then((docId) => { submissionState = { error: false, docId }; })
+      .catch(() => { submissionState = { error: true, docId: null }; });
 
     setTimeout(() => {
-      submissionResult.then(({ error, docId }) => {
-        createRankingScreen(score, error, docId);
-      });
+      createRankingScreen(score, submissionState.error, submissionState.docId);
     }, GAME_OVER_TRANSITION_MS);
   }
 

--- a/assets/js/vite-env.d.ts
+++ b/assets/js/vite-env.d.ts
@@ -4,6 +4,8 @@ interface ImportMetaEnv {
   readonly VITE_FIREBASE_API_KEY: string;
   readonly VITE_FIREBASE_PROJECT_ID: string;
   readonly VITE_FIREBASE_APP_ID: string;
+  readonly VITE_FIREBASE_MESSAGING_SENDER_ID: string;
+  readonly VITE_FIREBASE_MEASUREMENT_ID: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to Firebase init env wiring and client-side ranking UX; leaderboard writes still go through the same `submitScore` path.
> 
> **Overview**
> Completes Firebase client setup by wiring **`messagingSenderId`** and **`measurementId`** through Vite env types, `firebase.ts` config, and the GitHub Pages build workflow (new repository secrets at deploy time).
> 
> The Hall of Fame flow now keeps the in-flight **`submitScore`** promise and runs **`fetchTopScores`** in parallel via **`Promise.all`**, instead of resolving submission before navigation. The “score could not be saved” message is shown only after load (or on fetch failure) by inserting the banner in the DOM, and retries reuse the same submission promise so a slow save is not double-submitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee12c1a2a452f839a446f3b0fc6aad7485463649. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->