### PR TITLE
fix: Refine error handling in score submission

### DIFF
--- a/assets/js/main.ts
+++ b/assets/js/main.ts
@@ -261,12 +261,19 @@ function main(): void {
     if (!listEl) return;
 
     try {
-      const [scores, { error: submissionError, docId: submittedDocId }] = await Promise.all([
-        fetchTopScores(10),
-        submission,
-      ]);
+      const scores = await fetchTopScores(10);
 
       if (!mainElement.querySelector('.ranking-list')) return; // navigated away
+
+      // Give submission up to 1 s after scores arrive; fall back to failed if still pending
+      const { error: submissionError, docId: submittedDocId } = await Promise.race([
+        submission,
+        new Promise<{ error: boolean; docId: string | null }>((resolve) =>
+          setTimeout(() => resolve({ error: true, docId: null }), 1000)
+        ),
+      ]);
+
+      if (!mainElement.querySelector('.ranking-list')) return;
 
       if (submissionError && !mainElement.querySelector('.ranking-save-error')) {
         const overlay = mainElement.querySelector('.ranking-overlay');
@@ -329,7 +336,10 @@ function main(): void {
       listEl.innerHTML = html;
     } catch {
       if (!mainElement.querySelector('.ranking-list')) return;
-      const { error: submissionError } = await submission;
+      const { error: submissionError } = await Promise.race([
+        submission,
+        Promise.resolve<{ error: boolean; docId: string | null }>({ error: true, docId: null }),
+      ]);
       if (!mainElement.querySelector('.ranking-list')) return;
       if (submissionError && !mainElement.querySelector('.ranking-save-error')) {
         const overlay = mainElement.querySelector('.ranking-overlay');

--- a/assets/js/main.ts
+++ b/assets/js/main.ts
@@ -338,7 +338,9 @@ function main(): void {
       if (!mainElement.querySelector('.ranking-list')) return;
       const { error: submissionError } = await Promise.race([
         submission,
-        Promise.resolve<{ error: boolean; docId: string | null }>({ error: true, docId: null }),
+        new Promise<{ error: boolean; docId: string | null }>((resolve) =>
+          setTimeout(() => resolve({ error: true, docId: null }), 1000)
+        ),
       ]);
       if (!mainElement.querySelector('.ranking-list')) return;
       if (submissionError && !mainElement.querySelector('.ranking-save-error')) {


### PR DESCRIPTION
… to ensure timely fallback and prevent navigation issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to post-game ranking UX; worst case is showing a save error or missing highlight when submission completes after 1s.
> 
> **Overview**
> **Ranking screen no longer blocks on score submission.** `loadRanking` fetches the top scores first, then waits on the in-flight `submitScore` promise with a **1 second** `Promise.race` timeout so the list can render even when Firebase is slow.
> 
> If submission is still pending after that window (or times out), it is treated as a failed save (`error: true`, no `docId`), which drives the existing “score could not be saved” banner and skips highlighting the player row via `submittedDocId`. The same race is applied in the **catch** path when `fetchTopScores` fails, so a hung submission does not block the error/retry UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a2e8c5010c3b157f217b6280440420f92a36eb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->