### PR TITLE
style: remove object-fit property from footer-avatar

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -248,7 +248,6 @@ main {
   width: 2rem;
   height: 2rem;
   border-radius: 50%;
-  object-fit: cover;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single cosmetic CSS change to the site footer with no logic or data impact.
> 
> **Overview**
> Removes **`object-fit: cover`** from the `.footer-avatar` rule in `assets/css/style.css`.
> 
> The footer still sizes the avatar at **2rem** with a circular **`border-radius`**. Without `object-fit`, how the linked SVG scales inside that box may differ from the previous cropped “cover” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc261232af6e1b4808bfe333e7af226f149c5be5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->